### PR TITLE
Fix Azure Metadata URL

### DIFF
--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -9,7 +9,7 @@ readonly SUPERVISOR_CONFIG_PATH="/etc/supervisor/conf.d/run-vault.conf"
 readonly DEFAULT_PORT=8200
 readonly DEFAULT_LOG_LEVEL="info"
 
-readonly AZURE_INSTANCE_METADATA_URL="http://169.254.169.254/metadata/instance?api-version=2017-04-02"
+readonly AZURE_INSTANCE_METADATA_URL="http://169.254.169.254/metadata/instance?api-version=2017-08-01"
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_NAME="$(basename "$0")"

--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -9,7 +9,7 @@ readonly SUPERVISOR_CONFIG_PATH="/etc/supervisor/conf.d/run-vault.conf"
 readonly DEFAULT_PORT=8200
 readonly DEFAULT_LOG_LEVEL="info"
 
-readonly AZURE_INSTANCE_METADATA_URL="http://169.254.169.254/metadata/instance?api-version=2017-07-01"
+readonly AZURE_INSTANCE_METADATA_URL="http://169.254.169.254/metadata/instance?api-version=2017-04-02"
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_NAME="$(basename "$0")"


### PR DESCRIPTION
As per https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service

It doesn't work as expected in current master url setting:
```
$ curl --silent --show-error --header Metadata:true --location "http://169.254.169.254/metadata/instance?api-version=2017-07-01"
{ "error": "Not found. Invalid version requested" }
```

With current fix (sets proper ip address in /opt/vault/config/default.hcl):
```
$ curl --silent --show-error --header Metadata:true --location "http://169.254.169.254/metadata/instance?api-version=2017-04-02"
{"compute":{"location":"northeurope","name":"vault-cluster_0","offer":"","osType":"Linux","platformFaultDomain":"0","platformUpdateDomain":"0","publisher":"","sku":"","version":"","vmId":"7f7e2862-4d06-4df3-bcc3-0a4e83822721","vmSize":"Standard_A0"},"network":{"interface":[{"ipv4":{"ipAddress":[{"privateIpAddress":"10.10.235.7","publicIpAddress":""}],"subnet":[{"address":"10.10.235.0","prefix":"24"}]},"ipv6":{"ipAddress":[]},"macAddress":"000D3AB7733F"}]}}
```
