### PR TITLE
[feature] enable log dir for audit log

### DIFF
--- a/modules/install-vault/install-vault
+++ b/modules/install-vault/install-vault
@@ -116,6 +116,7 @@ function create_vault_install_paths {
   sudo mkdir -p "$path/data"
   sudo mkdir -p "$path/log"
   sudo mkdir -p "$path/tls"
+  sudo ln -nsf "$path/log" /var/log/vault
 
   log_info "Changing ownership of $path to $username"
   sudo chown -R "$username:$username" "$path"


### PR DESCRIPTION
By default, vault_audit.log is being created in /var/log/vault, but this folder doesn't exist.
Current fix is just simply creating this folder by linking to "$path/log"

```
$ ls -l /var/log/vault/
total 9964
drwxr-xr-x 2 vault vault     4096 Nov  2 07:30 ./
drwxr-xr-x 7 vault vault     4096 Nov  1 15:31 ../
-rw------- 1 vault vault    10713 Nov  2 07:31 vault_audit.log
-rw-r--r-- 1 root  root  10169870 Nov  2 07:32 vault-error.log
-rw-r--r-- 1 root  root      4957 Nov  2 07:30 vault-stdout.log
```