### PR TITLE
Fix HA config api_addr.

### DIFF
--- a/modules/run-vault/README.md
+++ b/modules/run-vault/README.md
@@ -92,9 +92,9 @@ available.
       connection is to a Consul agent running on the same server.
     * [path](https://www.vaultproject.io/docs/configuration/storage/consul.html#path): Set to `vault/`.
     * [service](https://www.vaultproject.io/docs/configuration/storage/consul.html#service): Set to `vault`.  
-    * [redirect_addr](https://www.vaultproject.io/docs/configuration/storage/consul.html#redirect_addr): 
-      Set to `https://<PRIVATE_IP>:<CLUSTER_PORT>` where `PRIVATE_IP` is the Instance's private IP and `CLUSTER_PORT` is
-      the value passed to `--cluster-port`.  
+	* [api_addr](https://www.vaultproject.io/docs/configuration/index.html#api_addr):
+	  Set to `https://<PRIVATE_IP>:<PORT>` where `PRIVATE_IP` is the Instance's private IP and `PORT` is
+	  the value passed to `--port`.
     * [cluster_addr](https://www.vaultproject.io/docs/configuration/storage/consul.html#cluster_addr): 
       Set to `https://<PRIVATE_IP>:<CLUSTER_PORT>` where `PRIVATE_IP` is the Instance's private IP and `CLUSTER_PORT` is
       the value passed to `--cluster-port`.

--- a/modules/run-vault/run-vault
+++ b/modules/run-vault/run-vault
@@ -131,7 +131,7 @@ ha_storage "consul" {
 
   # HA settings
   cluster_addr  = "https://$instance_ip_address:$cluster_port"
-  redirect_addr = "https://$instance_ip_address:$cluster_port"
+  api_addr = "https://$instance_ip_address:$port"
 }
 
 listener "tcp" {


### PR DESCRIPTION
This PR implements the same changes as [this PR in terraform-aws-vault](https://github.com/hashicorp/terraform-aws-vault/pull/61) which addresses [hashicorp/vault#4383](https://github.com/hashicorp/vault/issues/4383). It fixes an issue for AzureRM same [as described here](https://github.com/hashicorp/terraform-google-vault/issues/14) for GCP.

I have tested this change and it fixes the problem for AzureRM.