### PR TITLE
Splatting for ip address output is incorrect

### DIFF
--- a/modules/vault-cluster/outputs.tf
+++ b/modules/vault-cluster/outputs.tf
@@ -15,5 +15,5 @@ output "storage_containter_id" {
 }
 
 output "load_balancer_ip_address" {
-  value = "${azurerm_public_ip.vault_access.ip_address}"
+  value = "${azurerm_public_ip.vault_access.*.ip_address}"
 }


### PR DESCRIPTION
Warning: output "load_balancer_ip_address": must use splat syntax to access azurerm_public_ip.vault_access attribute "ip_address", because it has "count" set; use azurerm_public_ip.vault_access.*.ip_address to obtain a list of the attributes across all instances